### PR TITLE
Update JQueryProviderAsset.php

### DIFF
--- a/src/Asset/JQueryProviderAsset.php
+++ b/src/Asset/JQueryProviderAsset.php
@@ -16,7 +16,7 @@ final class JQueryProviderAsset extends AssetBundle
     /**
      * @phpstan-var array<array-key, mixed>
      */
-    public $depends = [DateTimePickerAsset::class];
+    public $depends = ['yii\web\JqueryAsset',DateTimePickerAsset::class];
 
     public function __construct()
     {


### PR DESCRIPTION
JQueryProviderAsset depends on Jquery assets. Fixed dependency

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset loading by ensuring the required jQuery library is explicitly included before the DateTimePicker component. This enhances compatibility and prevents potential issues with missing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->